### PR TITLE
feat: a11y改善（lang=ja / slider aria-label / 選択状態 / skip link）

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="ja">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -137,12 +137,12 @@ function App() {
       <main className="max-w-7xl mx-auto px-4 py-8">
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
           {/* 設定パネル */}
-          <div id="settings" className="no-print">
+          <div id="settings" tabIndex={-1} className="no-print">
             <SettingsPanel />
           </div>
 
           {/* プレビュー */}
-          <div id="preview" className="lg:col-span-2">
+          <div id="preview" tabIndex={-1} className="lg:col-span-2">
             <div className="preview-area">
               <div className="flex items-center justify-between mb-4 no-print">
                 <h2 className="section-title text-lg">プレビュー</h2>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -110,6 +110,14 @@ function App() {
 
   return (
     <div className="min-h-screen" style={{ background: 'var(--color-bg)' }}>
+      {/* Skip links */}
+      <a href="#settings" className="skip-link no-print">
+        設定へスキップ
+      </a>
+      <a href="#preview" className="skip-link no-print">
+        プレビューへスキップ
+      </a>
+
       {/* ヘッダー */}
       <header className="kanji-header no-print">
         <div className="max-w-7xl mx-auto px-6 py-6 relative z-10">
@@ -129,12 +137,12 @@ function App() {
       <main className="max-w-7xl mx-auto px-4 py-8">
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
           {/* 設定パネル */}
-          <div className="no-print">
+          <div id="settings" className="no-print">
             <SettingsPanel />
           </div>
 
           {/* プレビュー */}
-          <div className="lg:col-span-2">
+          <div id="preview" className="lg:col-span-2">
             <div className="preview-area">
               <div className="flex items-center justify-between mb-4 no-print">
                 <h2 className="section-title text-lg">プレビュー</h2>

--- a/src/components/settings/GradeSelector.tsx
+++ b/src/components/settings/GradeSelector.tsx
@@ -18,6 +18,7 @@ export function GradeSelector({ value, onChange, excludedCount, onOpenExcludeMod
             key={gradeValue}
             type="button"
             onClick={() => onChange(gradeValue)}
+            aria-pressed={value === gradeValue}
             className={`relative p-3 rounded-xl text-left transition-all duration-200 ${
               value === gradeValue ? 'shadow-md' : 'hover:shadow-sm'
             }`}

--- a/src/components/settings/ModeSelector.tsx
+++ b/src/components/settings/ModeSelector.tsx
@@ -29,6 +29,7 @@ export function ModeSelector({ value, onChange }: Props) {
             key={modeValue}
             type="button"
             onClick={() => onChange(modeValue)}
+            aria-pressed={value === modeValue}
             className={`relative p-3 rounded-xl text-left transition-all duration-200 ${
               value === modeValue ? 'shadow-sm' : 'hover:shadow-sm'
             }`}

--- a/src/components/settings/PrintOptions.tsx
+++ b/src/components/settings/PrintOptions.tsx
@@ -33,6 +33,7 @@ export function PrintOptions({
             onChange={(e) => onSettingsChange({ pageCount: Number(e.target.value) })}
             className="flex-1 h-2 rounded-lg cursor-pointer"
             style={{ background: 'var(--color-border)' }}
+            aria-label="ページ数"
           />
           <div
             className="px-3 py-1 rounded-lg text-sm font-bold min-w-[80px] text-center"
@@ -58,6 +59,7 @@ export function PrintOptions({
             onChange={(e) => onSettingsChange({ practiceColumns: Number(e.target.value) })}
             className="w-full h-2 rounded-lg cursor-pointer"
             style={{ background: 'var(--color-border)' }}
+            aria-label="練習マス数"
           />
           <div
             className="flex justify-between text-xs mt-1"
@@ -82,6 +84,7 @@ export function PrintOptions({
           onChange={(e) => onSettingsChange({ cellSize: Number(e.target.value) })}
           className="w-full h-2 rounded-lg cursor-pointer"
           style={{ background: 'var(--color-border)' }}
+          aria-label={`${currentModeSettings.cellSizeLabel}`}
         />
         <div
           className="flex justify-between text-xs mt-1"
@@ -102,6 +105,7 @@ export function PrintOptions({
                 key={value}
                 type="button"
                 onClick={() => onSettingsChange({ gridStyle: value as GridStyle })}
+                aria-pressed={settings.gridStyle === value}
                 className="p-2 rounded-lg text-sm font-medium transition-all"
                 style={{
                   background: settings.gridStyle === value ? 'var(--color-primary)' : 'white',

--- a/src/index.css
+++ b/src/index.css
@@ -37,8 +37,9 @@
 /* 教科書体フォント適用 */
 .font-textbook {
   font-family:
-    "Klee One", "UD Digi Kyokasho N-R", "UD デジタル 教科書体 N-R", "Yu Kyokasho", "游教科書体",
-    "ヒラギノ丸ゴ Pro", "Hiragino Maru Gothic Pro", serif;
+    "Klee One", "UD Digi Kyokasho N-R", "UD デジタル 教科書体 N-R",
+    "Yu Kyokasho", "游教科書体", "ヒラギノ丸ゴ Pro", "Hiragino Maru Gothic Pro",
+    serif;
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
 }
@@ -189,7 +190,11 @@
 }
 
 .kanji-header {
-  background: linear-gradient(135deg, var(--color-primary) 0%, var(--color-primary-dark) 100%);
+  background: linear-gradient(
+    135deg,
+    var(--color-primary) 0%,
+    var(--color-primary-dark) 100%
+  );
   color: white;
   position: relative;
   overflow: hidden;
@@ -221,7 +226,11 @@
 
 /* ボタンスタイル */
 .btn-primary {
-  background: linear-gradient(135deg, var(--color-primary) 0%, var(--color-primary-dark) 100%);
+  background: linear-gradient(
+    135deg,
+    var(--color-primary) 0%,
+    var(--color-primary-dark) 100%
+  );
   color: white;
   border: none;
   border-radius: 0.75rem;
@@ -258,7 +267,11 @@
 
 .selection-card.selected {
   border-color: var(--color-primary);
-  background: linear-gradient(135deg, rgba(197, 61, 67, 0.05) 0%, rgba(197, 61, 67, 0.1) 100%);
+  background: linear-gradient(
+    135deg,
+    rgba(197, 61, 67, 0.05) 0%,
+    rgba(197, 61, 67, 0.1) 100%
+  );
 }
 
 .selection-card.selected::before {
@@ -312,6 +325,28 @@ input[type="checkbox"]:checked {
 /* スライダーカスタム */
 input[type="range"] {
   accent-color: var(--color-primary);
+}
+
+/* Skip link - キーボードナビゲーション用 */
+.skip-link {
+  position: absolute;
+  top: -100%;
+  left: 1rem;
+  z-index: 100;
+  padding: 0.75rem 1.5rem;
+  background: var(--color-primary);
+  color: white;
+  border-radius: 0 0 0.5rem 0.5rem;
+  font-weight: 600;
+  font-size: 0.875rem;
+  text-decoration: none;
+  transition: top 0.2s ease;
+}
+
+.skip-link:focus {
+  top: 0;
+  outline: 2px solid var(--color-primary-dark);
+  outline-offset: 2px;
 }
 
 /* 装飾的な漢字背景 */


### PR DESCRIPTION
## Summary

- `<html lang="en">` → `<html lang="ja">` に修正（日本語UIに適切な言語属性）
- ページ数・練習マス数・マスサイズの各rangeスライダーに `aria-label` を付与
- 学年選択・プリント種類・ガイドラインのトグルボタンに `aria-pressed` 属性を追加
- Skip link（設定へスキップ / プレビューへスキップ）を追加し、キーボードユーザーの操作性を向上

Closes #21

## Test plan

- [x] TypeScript型チェック通過
- [x] Biome lint/format チェック通過
- [x] ユニットテスト 256件全パス
- [ ] ブラウザでTabキー操作を確認し、Skip linkが表示されることを検証
- [ ] スクリーンリーダーでスライダーのラベルが読み上げられることを確認
- [ ] 学年/モード変更時に `aria-pressed` の値が正しく切り替わることを確認
- [ ] 印刷プレビュー/PDF生成に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)