### PR TITLE
feat: 学習プリセット（9級読み・9級書き取り・8級先取り）を追加

### DIFF
--- a/e2e/a4-layout-all-modes.spec.ts
+++ b/e2e/a4-layout-all-modes.spec.ts
@@ -31,7 +31,7 @@ test.describe('全モードA4レイアウト確認', () => {
   for (const mode of modes) {
     test(`${mode.name}モードがA4 1ページに収まる`, async ({ page }) => {
       // モード選択
-      await page.click(`text=${mode.selector}`);
+      await page.getByTestId(`mode-selector-${mode.mode}`).click();
       await page.waitForTimeout(500);
 
       // フッターのページ情報を取得
@@ -61,7 +61,7 @@ test.describe('全モードA4レイアウト確認', () => {
     const cellSizeSlider = page.locator('input[type="range"][min="12"][max="25"]');
 
     for (const mode of modes) {
-      await page.click(`text=${mode.selector}`);
+      await page.getByTestId(`mode-selector-${mode.mode}`).click();
       await page.waitForTimeout(200);
       await cellSizeSlider.fill('12');
       await page.waitForTimeout(300);
@@ -82,7 +82,7 @@ test.describe('全モードA4レイアウト確認', () => {
     const cellSizeSlider = page.locator('input[type="range"][min="12"][max="25"]');
 
     for (const mode of modes) {
-      await page.click(`text=${mode.selector}`);
+      await page.getByTestId(`mode-selector-${mode.mode}`).click();
       await page.waitForTimeout(200);
       await cellSizeSlider.fill('25');
       await page.waitForTimeout(300);

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -20,7 +20,13 @@ import {
   generateRadicalQuestions,
 } from '../utils/radicalQuestionGenerator';
 import { ExcludeKanjiModal } from './modals/ExcludeKanjiModal';
-import { GradeSelector, ModeSelector, PrintOptions } from './settings';
+import {
+  GradeSelector,
+  getLearningPresetSettings,
+  LearningPresetSelector,
+  ModeSelector,
+  PrintOptions,
+} from './settings';
 
 export function SettingsPanel() {
   const { settings, setSettings, setQuestions, excludedKanji, generationCounter } = useStore();
@@ -129,6 +135,11 @@ export function SettingsPanel() {
         onChange={(grade) => setSettings({ grade })}
         excludedCount={currentExcluded.length}
         onOpenExcludeModal={() => setIsExcludeModalOpen(true)}
+      />
+
+      <LearningPresetSelector
+        settings={settings}
+        onSelect={(presetId) => setSettings(getLearningPresetSettings(presetId))}
       />
 
       <ModeSelector value={settings.mode} onChange={(mode) => setSettings({ mode })} />

--- a/src/components/settings/LearningPresetSelector.tsx
+++ b/src/components/settings/LearningPresetSelector.tsx
@@ -1,0 +1,112 @@
+import type { Settings } from '../../types';
+import {
+  getMatchingLearningPresetId,
+  grades,
+  type LearningPresetId,
+  learningPresets,
+  modes,
+} from './config';
+
+interface Props {
+  settings: Settings;
+  onSelect: (presetId: LearningPresetId) => void;
+}
+
+export function LearningPresetSelector({ settings, onSelect }: Props) {
+  const activePresetId = getMatchingLearningPresetId(settings);
+
+  return (
+    <div className="p-4 rounded-xl space-y-3" style={{ background: 'var(--color-bg-warm)' }}>
+      <div>
+        <label className="section-title">学習プリセット</label>
+        <p className="text-xs mt-2" style={{ color: 'var(--color-text-muted)' }}>
+          学習の開始点をまとめて反映します。あとから個別設定で微調整できます。
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 gap-2">
+        {learningPresets.map(({ id, label, description, settings: presetSettings }) => {
+          const isActive = activePresetId === id;
+          const gradeLabel =
+            grades.find(({ value }) => value === presetSettings.grade)?.label ??
+            `${presetSettings.grade}年生`;
+          const modeLabel =
+            modes.find(({ value }) => value === presetSettings.mode)?.label ?? presetSettings.mode;
+
+          return (
+            <button
+              key={id}
+              type="button"
+              onClick={() => onSelect(id)}
+              aria-pressed={isActive}
+              className={`p-3 rounded-xl text-left transition-all duration-200 ${
+                isActive ? 'shadow-sm' : 'hover:shadow-sm'
+              }`}
+              style={{
+                background: isActive
+                  ? 'linear-gradient(135deg, rgba(197, 61, 67, 0.08) 0%, rgba(197, 61, 67, 0.15) 100%)'
+                  : 'white',
+                border: `2px solid ${isActive ? 'var(--color-primary)' : 'var(--color-border)'}`,
+              }}
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <div
+                    className="font-medium text-sm"
+                    style={{
+                      color: isActive ? 'var(--color-primary-dark)' : 'var(--color-text)',
+                    }}
+                  >
+                    {label}
+                  </div>
+                  <div className="text-xs mt-1" style={{ color: 'var(--color-text-muted)' }}>
+                    {description}
+                  </div>
+                  <div className="flex flex-wrap gap-2 mt-2 text-xs">
+                    <span
+                      className="px-2 py-1 rounded-full"
+                      style={{
+                        background: 'var(--color-border-light)',
+                        color: 'var(--color-text)',
+                      }}
+                    >
+                      {gradeLabel}
+                    </span>
+                    <span
+                      className="px-2 py-1 rounded-full"
+                      style={{
+                        background: 'var(--color-border-light)',
+                        color: 'var(--color-text)',
+                      }}
+                    >
+                      {modeLabel}
+                    </span>
+                    <span
+                      className="px-2 py-1 rounded-full"
+                      style={{
+                        background: 'var(--color-border-light)',
+                        color: 'var(--color-text)',
+                      }}
+                    >
+                      {presetSettings.pageCount}枚
+                    </span>
+                  </div>
+                </div>
+
+                <span
+                  className="shrink-0 px-2 py-1 rounded-full text-xs font-medium"
+                  style={{
+                    background: isActive ? 'var(--color-primary)' : 'var(--color-border-light)',
+                    color: isActive ? 'white' : 'var(--color-text-muted)',
+                  }}
+                >
+                  {isActive ? '適用中' : '適用'}
+                </span>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/settings/ModeSelector.tsx
+++ b/src/components/settings/ModeSelector.tsx
@@ -29,6 +29,7 @@ export function ModeSelector({ value, onChange }: Props) {
             key={modeValue}
             type="button"
             onClick={() => onChange(modeValue)}
+            data-testid={`mode-selector-${modeValue}`}
             aria-pressed={value === modeValue}
             className={`relative p-3 rounded-xl text-left transition-all duration-200 ${
               value === modeValue ? 'shadow-sm' : 'hover:shadow-sm'

--- a/src/components/settings/__tests__/learningPresets.test.ts
+++ b/src/components/settings/__tests__/learningPresets.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+import type { Settings } from '../../../types';
+import {
+  applyLearningPreset,
+  getLearningPresetSettings,
+  getMatchingLearningPresetId,
+  learningPresets,
+} from '../config';
+
+const baseSettings: Settings = {
+  grade: 6,
+  mode: 'antonym',
+  pageCount: 4,
+  random: false,
+  gridStyle: 'none',
+  cellSize: 25,
+  practiceColumns: 3,
+  showHint: false,
+  title: 'カスタム設定',
+};
+
+describe('learning presets', () => {
+  it('defines the three learner presets with the required fields', () => {
+    expect(learningPresets.map(({ label }) => label)).toEqual([
+      '9級 読み定着',
+      '9級 書き取り',
+      '8級 先取り',
+    ]);
+
+    for (const preset of learningPresets) {
+      expect(preset.settings).toMatchObject({
+        grade: expect.any(Number),
+        mode: expect.any(String),
+        pageCount: expect.any(Number),
+        cellSize: expect.any(Number),
+        practiceColumns: expect.any(Number),
+        showHint: expect.any(Boolean),
+        title: expect.any(String),
+      });
+    }
+  });
+
+  it('applies the 9級 読み定着 preset as grade 2 reading practice', () => {
+    const next = applyLearningPreset(baseSettings, 'kanken9-reading');
+
+    expect(next).toMatchObject({
+      grade: 2,
+      mode: 'reading',
+      pageCount: 2,
+      cellSize: 17,
+      practiceColumns: 6,
+      showHint: false,
+      title: '9級 読み定着プリント',
+    });
+    expect(next.random).toBe(false);
+    expect(next.gridStyle).toBe('none');
+  });
+
+  it('applies the 9級 書き取り preset with guided writing defaults', () => {
+    const next = applyLearningPreset(baseSettings, 'kanken9-writing');
+
+    expect(next).toMatchObject({
+      grade: 2,
+      mode: 'writing',
+      pageCount: 2,
+      cellSize: 15,
+      practiceColumns: 7,
+      showHint: true,
+      title: '9級 書き取りプリント',
+      gridStyle: 'cross',
+    });
+  });
+
+  it('applies the 8級 先取り preset as a lighter grade 3 start point', () => {
+    const next = applyLearningPreset(baseSettings, 'kanken8-preview');
+
+    expect(next).toMatchObject({
+      grade: 3,
+      mode: 'reading',
+      pageCount: 1,
+      cellSize: 18,
+      practiceColumns: 5,
+      showHint: false,
+      title: '8級 先取りプリント',
+    });
+  });
+
+  it('detects the active preset only while its values still match', () => {
+    const applied = applyLearningPreset(baseSettings, 'kanken9-writing');
+    expect(getMatchingLearningPresetId(applied)).toBe('kanken9-writing');
+
+    const customized: Settings = {
+      ...applied,
+      title: '9級 書き取りプリント（復習）',
+    };
+    expect(getMatchingLearningPresetId(customized)).toBeNull();
+  });
+
+  it('overwrites manual changes when another preset is selected', () => {
+    const writingPreset = getLearningPresetSettings('kanken9-writing');
+    const next = applyLearningPreset(
+      {
+        ...baseSettings,
+        ...getLearningPresetSettings('kanken9-reading'),
+        pageCount: 6,
+        cellSize: 12,
+        practiceColumns: 11,
+        showHint: true,
+        title: '個別に変更したタイトル',
+      },
+      'kanken9-writing',
+    );
+
+    expect(next).toMatchObject(writingPreset);
+  });
+});

--- a/src/components/settings/config.ts
+++ b/src/components/settings/config.ts
@@ -2,7 +2,9 @@
  * 設定パネルで使用する定数とマッピング
  */
 
-import type { Grade, GridStyle, PrintMode } from '../../types';
+import { CELL_SIZE } from '../../constants/print';
+import type { Grade, GridStyle, PrintMode, Settings } from '../../types';
+import { calculateRecommendedPracticeColumns } from '../../utils/layout';
 
 // 学年オプション
 export const grades: { value: Grade; label: string }[] = [
@@ -42,6 +44,119 @@ export const gridStyles: { value: GridStyle; label: string }[] = [
   { value: 'dots', label: 'ドットガイド' },
   { value: 'none', label: 'ガイドなし' },
 ];
+
+type LearningPresetSettingKey =
+  | 'grade'
+  | 'mode'
+  | 'pageCount'
+  | 'cellSize'
+  | 'practiceColumns'
+  | 'showHint'
+  | 'title';
+
+export type LearningPresetSettings = Pick<Settings, LearningPresetSettingKey> &
+  Partial<Pick<Settings, 'gridStyle'>>;
+
+export type LearningPresetId = 'kanken9-reading' | 'kanken9-writing' | 'kanken8-preview';
+
+export interface LearningPreset {
+  id: LearningPresetId;
+  label: string;
+  description: string;
+  settings: LearningPresetSettings;
+}
+
+function createLearningPresetSettings(
+  overrides: Partial<LearningPresetSettings>,
+): LearningPresetSettings {
+  return {
+    grade: 2,
+    mode: 'reading',
+    pageCount: 1,
+    cellSize: CELL_SIZE.DEFAULT,
+    practiceColumns: calculateRecommendedPracticeColumns(CELL_SIZE.DEFAULT),
+    showHint: false,
+    title: '漢字練習プリント',
+    ...overrides,
+  };
+}
+
+export const learningPresets: LearningPreset[] = [
+  {
+    id: 'kanken9-reading',
+    label: '9級 読み定着',
+    description: '2年生の漢字を大きめ表示で読み中心に反復します。',
+    settings: createLearningPresetSettings({
+      grade: 2,
+      mode: 'reading',
+      pageCount: 2,
+      cellSize: 17,
+      practiceColumns: calculateRecommendedPracticeColumns(17),
+      showHint: false,
+      title: '9級 読み定着プリント',
+    }),
+  },
+  {
+    id: 'kanken9-writing',
+    label: '9級 書き取り',
+    description: '2年生の漢字を十字ガイド付きでしっかり書き取ります。',
+    settings: createLearningPresetSettings({
+      grade: 2,
+      mode: 'writing',
+      pageCount: 2,
+      cellSize: CELL_SIZE.DEFAULT,
+      practiceColumns: calculateRecommendedPracticeColumns(CELL_SIZE.DEFAULT),
+      showHint: true,
+      title: '9級 書き取りプリント',
+      gridStyle: 'cross',
+    }),
+  },
+  {
+    id: 'kanken8-preview',
+    label: '8級 先取り',
+    description: '3年生の漢字を1ページだけ軽めに触れて負荷を抑えます。',
+    settings: createLearningPresetSettings({
+      grade: 3,
+      mode: 'reading',
+      pageCount: 1,
+      cellSize: 18,
+      practiceColumns: calculateRecommendedPracticeColumns(18),
+      showHint: false,
+      title: '8級 先取りプリント',
+    }),
+  },
+];
+
+const learningPresetMap = learningPresets.reduce<Record<LearningPresetId, LearningPreset>>(
+  (map, preset) => {
+    map[preset.id] = preset;
+    return map;
+  },
+  {} as Record<LearningPresetId, LearningPreset>,
+);
+
+export function getLearningPresetSettings(id: LearningPresetId): LearningPresetSettings {
+  return { ...learningPresetMap[id].settings };
+}
+
+export function applyLearningPreset(settings: Settings, id: LearningPresetId): Settings {
+  return { ...settings, ...getLearningPresetSettings(id) };
+}
+
+export function getMatchingLearningPresetId(settings: Settings): LearningPresetId | null {
+  for (const preset of learningPresets) {
+    const isMatch = Object.entries(preset.settings).every(([key, value]) => {
+      const settingsKey = key as keyof Settings;
+      return settings[settingsKey] === value;
+    });
+
+    if (isMatch) {
+      return preset.id;
+    }
+  }
+
+  return null;
+}
 
 // モードごとの設定適用マップ
 export interface ModeSettingsConfig {

--- a/src/components/settings/config.ts
+++ b/src/components/settings/config.ts
@@ -52,10 +52,10 @@ type LearningPresetSettingKey =
   | 'cellSize'
   | 'practiceColumns'
   | 'showHint'
-  | 'title';
+  | 'title'
+  | 'gridStyle';
 
-export type LearningPresetSettings = Pick<Settings, LearningPresetSettingKey> &
-  Partial<Pick<Settings, 'gridStyle'>>;
+export type LearningPresetSettings = Pick<Settings, LearningPresetSettingKey>;
 
 export type LearningPresetId = 'kanken9-reading' | 'kanken9-writing' | 'kanken8-preview';
 
@@ -77,6 +77,7 @@ function createLearningPresetSettings(
     practiceColumns: calculateRecommendedPracticeColumns(CELL_SIZE.DEFAULT),
     showHint: false,
     title: '漢字練習プリント',
+    gridStyle: 'none',
     ...overrides,
   };
 }

--- a/src/components/settings/index.ts
+++ b/src/components/settings/index.ts
@@ -1,5 +1,20 @@
-export type { ModeSettingsConfig } from './config';
-export { grades, gridStyles, modeSettings, modes } from './config';
+export type {
+  LearningPreset,
+  LearningPresetId,
+  LearningPresetSettings,
+  ModeSettingsConfig,
+} from './config';
+export {
+  applyLearningPreset,
+  getLearningPresetSettings,
+  getMatchingLearningPresetId,
+  grades,
+  gridStyles,
+  learningPresets,
+  modeSettings,
+  modes,
+} from './config';
 export { GradeSelector } from './GradeSelector';
+export { LearningPresetSelector } from './LearningPresetSelector';
 export { ModeSelector } from './ModeSelector';
 export { PrintOptions } from './PrintOptions';


### PR DESCRIPTION
## Summary
- add learning preset definitions plus pure apply/match helpers for the three learner flows
- add a learning preset selector to the settings panel while keeping existing manual controls intact
- add unit tests covering preset defaults, active-state detection, and explicit overwrite behavior

## Testing
- npm run test:unit
- npm run build
- npm run check

Closes #25