### PR TITLE
fix: 教科書体フォント(Klee One)をWebフォントとして読み込む

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@import url("https://fonts.googleapis.com/css2?family=Klee+One:wght@400;600&display=swap");
 
 /* カラーパレット - 和風テーマ */
 :root {
@@ -25,16 +26,10 @@
   --color-border-light: #f0ebe3;
 }
 
-/* 教科書体フォントファミリー - Print optimized */
-@font-face {
-  font-family: "Klee One";
-  src: local("Klee One"), local("KleeOne-Regular");
-  font-weight: 400;
-  font-style: normal;
-  font-display: swap;
-}
-
-/* 教科書体フォント適用 */
+/* 教科書体フォント適用
+ * Klee One: Google Fonts経由でWebフォントとして読み込み（教科書体ベース）
+ * フォールバック: OS標準の教科書体 → 丸ゴシック → serif
+ */
 .font-textbook {
   font-family:
     "Klee One", "UD Digi Kyokasho N-R", "UD デジタル 教科書体 N-R",


### PR DESCRIPTION
## Summary

漢字練習プリントの漢字がゴシック体で表示される問題を修正。`.font-textbook` クラスは Klee One を `local()` のみで指定していたため、フォント未インストール環境（多くの macOS 標準環境含む）では `serif` フォールバックや OS 標準フォントに落ち、教科書体になっていなかった。

Google Fonts 経由で Klee One を Web フォントとして読み込むことで、全環境で教科書体表示を保証する。

## なぜ重要か

ゴシック体では とめ・はね・はらい が正しく表現されず、児童が誤った字形を学ぶ恐れがある。小学校教育では教科書体が標準であり、本ツールの目的（漢字練習）に直結する。

## Changes

- `src/index.css`: Google Fonts から Klee One (400/600) を読み込む `@import` を追加
- 不要になった `@font-face` ブロック（local-only）を削除
- フォールバックチェーンはそのまま維持（OS の教科書体 → 丸ゴシック → serif）

## Test plan

- [ ] `npm run dev` で問題セルの漢字が教科書体（とめ・はね・はらいあり）で表示される
- [ ] DevTools Network タブで `fonts.gstatic.com` から Klee One が読み込まれていることを確認
- [ ] 印刷プレビュー（PDF出力）でも教科書体が反映される
- [ ] `npm run build` がエラーなく通る（確認済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)