### PR TITLE
fix: Klee Oneフォントをindex.htmlのlinkタグで読み込む（#27の修正）

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,12 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Klee+One:wght@400;600&display=swap"
+    />
     <title>kanji-practice</title>
   </head>
   <body>

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,4 @@
 @import "tailwindcss";
-@import url("https://fonts.googleapis.com/css2?family=Klee+One:wght@400;600&display=swap");
 
 /* カラーパレット - 和風テーマ */
 :root {


### PR DESCRIPTION
## 背景

PR #27 で `src/index.css` に `@import url(...)` で Klee One を読み込んだが、CSS 仕様上 `@import` は他のすべてのルールより前に配置されている必要があり、`@import "tailwindcss"` の後ろに書かれていたため**本番で無効化**されていた。

実ブラウザで確認したところ、Klee One は読み込まれず `serif` にフォールバックし、教科書体になっていない状態だった。

## 修正内容

- `index.html` に `<link rel="stylesheet">` を追加し、Google Fonts の Klee One を確実に読み込む
- 不要になった `src/index.css` の `@import url(...)` を削除
- `preconnect` 2つも追加して描画ブロック時間を短縮

## 動作確認（ローカル）

`npm run dev` + Playwright で実ブラウザでの動作を検証済み：

- `fonts.gstatic.com` から woff2 スライスが 15 件 200 で取得
- `getComputedStyle().fontFamily` の先頭が `"Klee One"`
- スクリーンショットで筆運びのある教科書体（とめ・はね・はらい）を視覚確認

## Test plan

- [ ] `npm run build` 通過（確認済み: PR #27 と同等構成）
- [ ] Vercel preview で本番ビルドでも教科書体が表示される
- [ ] DevTools Network で `fonts.gstatic.com` の woff2 が 200 で読み込まれる
- [ ] 印刷プレビュー（PDF出力）にも反映される

🤖 Generated with [Claude Code](https://claude.com/claude-code)