### PR TITLE
feat: 例文写経の練習行を全マス書き取り対象に

### DIFF
--- a/src/components/WritingGrid.tsx
+++ b/src/components/WritingGrid.tsx
@@ -140,17 +140,21 @@ export function SentenceGrid({
 
   return (
     <div className="mb-2 avoid-break">
-      {/* お手本行 */}
+      {/* お手本行 - ターゲット漢字は太枠でハイライト */}
       <div
         className="flex flex-wrap mb-1"
         style={hasFurigana ? { paddingTop: `${cellSize * 0.3}mm` } : undefined}
       >
         {chars.map((char, i) => {
           const group = groupByStart.get(i);
+          const isTarget = targetKanji && char === targetKanji;
           return (
             <div
               key={i}
-              className="border border-gray-300 font-textbook text-gray-700 relative"
+              className={clsx(
+                'font-textbook text-gray-700 relative',
+                isTarget ? 'border-2 border-gray-800' : 'border border-gray-300',
+              )}
               style={{
                 width: `${cellSize}mm`,
                 height: `${cellSize}mm`,
@@ -182,52 +186,38 @@ export function SentenceGrid({
           );
         })}
       </div>
-      {/* 練習行 × N（同じ例文を繰り返し書写する） */}
+      {/* 練習行 × N（全マスを書き取り対象に。文字は表示せず罫線+ガイドのみ） */}
       {Array.from({ length: practiceRows }).map((_, rowIdx) => (
         // biome-ignore lint/suspicious/noArrayIndexKey: 練習行は同型の繰り返しでindexのみが識別子になる
         <div key={`practice-${rowIdx}`} className="flex flex-wrap">
-          {chars.map((char, i) => {
-            const isBlank = targetKanji && char === targetKanji;
+          {chars.map((_char, i) => {
+            const isTarget = targetKanji && chars[i] === targetKanji;
             return (
               <div
                 key={i}
                 className={clsx(
-                  'relative font-textbook',
-                  isBlank ? 'border border-gray-800 bg-white' : 'border border-gray-300',
+                  'relative font-textbook bg-white',
+                  isTarget ? 'border-2 border-gray-800' : 'border border-gray-300',
                 )}
                 style={{
                   width: `${cellSize}mm`,
                   height: `${cellSize}mm`,
                 }}
               >
-                {isBlank ? (
+                {/* 書き取り用ガイドライン（全マス共通） */}
+                {gridStyle === 'cross' && (
                   <>
-                    {/* 書き取り用ガイドライン */}
-                    {gridStyle === 'cross' && (
-                      <>
-                        <div className="absolute left-1/2 top-0 bottom-0 w-px bg-gray-300 -translate-x-1/2" />
-                        <div className="absolute top-1/2 left-0 right-0 h-px bg-gray-300 -translate-y-1/2" />
-                      </>
-                    )}
-                    {gridStyle === 'dots' && (
-                      <>
-                        <div className="absolute left-1/4 top-1/4 w-1 h-1 rounded-full bg-gray-300" />
-                        <div className="absolute right-1/4 top-1/4 w-1 h-1 rounded-full bg-gray-300" />
-                        <div className="absolute left-1/4 bottom-1/4 w-1 h-1 rounded-full bg-gray-300" />
-                        <div className="absolute right-1/4 bottom-1/4 w-1 h-1 rounded-full bg-gray-300" />
-                      </>
-                    )}
+                    <div className="absolute left-1/2 top-0 bottom-0 w-px bg-gray-300 -translate-x-1/2" />
+                    <div className="absolute top-1/2 left-0 right-0 h-px bg-gray-300 -translate-y-1/2" />
                   </>
-                ) : (
-                  <span
-                    className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 text-gray-400"
-                    style={{
-                      fontSize: `${cellSize * 0.7}mm`,
-                      lineHeight: 1,
-                    }}
-                  >
-                    {char}
-                  </span>
+                )}
+                {gridStyle === 'dots' && (
+                  <>
+                    <div className="absolute left-1/4 top-1/4 w-1 h-1 rounded-full bg-gray-300" />
+                    <div className="absolute right-1/4 top-1/4 w-1 h-1 rounded-full bg-gray-300" />
+                    <div className="absolute left-1/4 bottom-1/4 w-1 h-1 rounded-full bg-gray-300" />
+                    <div className="absolute right-1/4 bottom-1/4 w-1 h-1 rounded-full bg-gray-300" />
+                  </>
                 )}
               </div>
             );

--- a/src/components/WritingGrid.tsx
+++ b/src/components/WritingGrid.tsx
@@ -152,8 +152,8 @@ export function SentenceGrid({
             <div
               key={i}
               className={clsx(
-                'font-textbook text-gray-700 relative',
-                isTarget ? 'border-2 border-gray-800' : 'border border-gray-300',
+                'relative font-textbook text-gray-700 bg-white border',
+                isTarget ? 'border-2 border-gray-800' : 'border-gray-300',
               )}
               style={{
                 width: `${cellSize}mm`,
@@ -190,14 +190,14 @@ export function SentenceGrid({
       {Array.from({ length: practiceRows }).map((_, rowIdx) => (
         // biome-ignore lint/suspicious/noArrayIndexKey: 練習行は同型の繰り返しでindexのみが識別子になる
         <div key={`practice-${rowIdx}`} className="flex flex-wrap">
-          {chars.map((_char, i) => {
-            const isTarget = targetKanji && chars[i] === targetKanji;
+          {chars.map((char, i) => {
+            const isTarget = targetKanji && char === targetKanji;
             return (
               <div
                 key={i}
                 className={clsx(
-                  'relative font-textbook bg-white',
-                  isTarget ? 'border-2 border-gray-800' : 'border border-gray-300',
+                  'relative font-textbook bg-white border',
+                  isTarget ? 'border-2 border-gray-800' : 'border-gray-300',
                 )}
                 style={{
                   width: `${cellSize}mm`,


### PR DESCRIPTION
## 背景・狙い

例文写経モードの練習行はこれまで「ターゲット漢字のセルだけ書き取り用の白マス、それ以外は薄字の固定文字を表示（読む対象）」という構成だった。
しかし例文には対象漢字以外にも漢字・ひらがな・カタカナが含まれており、これらもついでに書写練習できれば、1問あたりの運筆練習量を大幅に増やせる。

## 変更内容

- 練習行: 全マスを罫線+ガイドラインのみ（薄字の固定文字を撤去）。漢字・ひらがな・カタカナ含めすべて書き取り対象に
- ターゲット漢字の視覚的区別: お手本行・練習行ともに `border-2 border-gray-800` で太枠ハイライト（学習対象であることを示す）
- ガイドライン (`gridStyle`): 全マス共通で `cross` / `dots` / `none` が適用される

## Before / After（cellSize=15mm, practiceRows=2 のイメージ）

```
[Before] 練習行
ぼ│く│は│学│校│へ
※「学」のみ太枠白マス、他は薄字の固定文字

[After] 練習行
□│□│□│■│□│□  (□=罫線+ガイド, ■=太枠+ガイド)
※全マスが書き取り可能、ターゲット「学」は太枠で強調
```

## 検証

- ✅ `npm run check:fix` — pass
- ✅ `npx tsc --noEmit` — エラーなし
- ✅ `npm run test:unit` — 307 / 307 PASS
- ✅ `npm run build` — 成功

## Test plan

- [ ] CI 全テスト pass
- [ ] Vercel preview で例文写経モードを確認:
  - 練習行の全マスが空（罫線+ガイドのみ）
  - ターゲット漢字が太枠で強調されている
  - お手本行のターゲット漢字も同様に強調されている
  - cellSize=12/15/25mm、practiceRows=1/2/3 すべてで A4 はみ出しなし
- [ ] 印刷プレビューでも同様に確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)