### PR TITLE
fix(app): hide debug overlay in production

### DIFF
--- a/e2e/debug-overlay.spec.ts
+++ b/e2e/debug-overlay.spec.ts
@@ -1,0 +1,11 @@
+import { expect, test } from '@playwright/test';
+
+test('開発環境ではレイアウトデバッグの導線を利用できる', async ({ page }) => {
+  await page.goto('/');
+
+  const debugButton = page.getByRole('button', { name: 'Debug', exact: true });
+  await expect(debugButton).toBeVisible();
+
+  await debugButton.click();
+  await expect(page.getByText('レイアウトデバッグ', { exact: true })).toBeVisible();
+});

--- a/e2e/production.spec.ts
+++ b/e2e/production.spec.ts
@@ -1,0 +1,15 @@
+import { expect, test } from '@playwright/test';
+
+test('production build ではデバッグ UI をマウントしない', async ({ page }) => {
+  await page.goto('./');
+  await expect(page.locator('.a4-page').first()).toBeVisible();
+
+  await expect(page.getByRole('button', { name: 'Debug', exact: true })).toHaveCount(0);
+
+  await page.keyboard.press('Control+Shift+D');
+  await expect(page.getByText('レイアウトデバッグ', { exact: true })).toHaveCount(0);
+
+  await expect(page.getByRole('button', { name: '問題を生成' })).toBeEnabled();
+  await expect(page.getByRole('button', { name: '印刷' })).toBeEnabled();
+  await expect(page.getByRole('button', { name: 'PDF保存' })).toBeEnabled();
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -16,12 +16,29 @@ export default defineConfig({
     {
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
+      testIgnore: '**/production.spec.ts',
+    },
+    {
+      name: 'production-chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        baseURL: 'http://localhost:4173/kanji-practice/',
+      },
+      testMatch: '**/production.spec.ts',
     },
   ],
-  webServer: {
-    command: 'npm run dev',
-    url: 'http://localhost:5173',
-    reuseExistingServer: !process.env.CI,
-    timeout: 120000,
-  },
+  webServer: [
+    {
+      command: 'npm run dev',
+      url: 'http://localhost:5173',
+      reuseExistingServer: !process.env.CI,
+      timeout: 120000,
+    },
+    {
+      command: 'npm run build && npm run preview -- --host 127.0.0.1 --port 4173',
+      url: 'http://localhost:4173/kanji-practice/',
+      reuseExistingServer: false,
+      timeout: 120000,
+    },
+  ],
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -72,7 +72,7 @@ function App() {
       </footer>
 
       {/* デバッグオーバーレイ */}
-      <DebugOverlay targetRef={printRef} />
+      {import.meta.env.DEV && <DebugOverlay targetRef={printRef} />}
     </div>
   );
 }


### PR DESCRIPTION
## 概要

本番ビルドで開発用 `DebugOverlay` のエントリポイントが表示されないようにしつつ、開発環境では既存のレイアウト検証導線を維持します。GitHub Pages 相当の production preview を対象とする E2E 設定と、開発・本番それぞれの回帰テストも追加します。

Closes #31

## 変更内容

- `src/App.tsx`
  - `DebugOverlay` を `import.meta.env.DEV` でガードし、production build ではマウントしないように変更
- `playwright.config.ts`
  - GitHub Pages のベースパスを使用する `production-chromium` project を追加
  - production preview を毎回新規に起動する設定へ変更
- `e2e/debug-overlay.spec.ts`
  - 開発環境で Debug UI にアクセスできることを検証
- `e2e/production.spec.ts`
  - production 環境で Debug UI とショートカットが利用できないことを検証
  - 主要な操作コントロールが有効なままであることを検証

## 動作確認

| 確認項目 | 結果 | 詳細 |
| --- | --- | --- |
| `./scripts/verify.sh --json` | ✅ pass | build: pass / lint: pass / format: n/a / typecheck: pass / test: pass |
| `npm run test:unit` | ✅ pass | 16 files、315 tests passed |
| `npx playwright test --list` | ✅ pass | 5 files、33 tests を列挙 |
| 対象 Playwright runtime tests | ⚠️ ローカル未検証 | managed macOS sandbox が `MachPortRendezvousServer` の登録を拒否し、Chromium を起動できなかったため。環境制約によるもので、pass 扱いにはしていません |
| 受け入れ条件のテスト定義 | ✅ 5/5 | Issue #31 の受け入れ条件すべてを自動チェックまたは回帰テスト定義でカバー |
| セキュリティレビュー | ✅ findings なし | 個人情報・トラッキング・権限変更なし |
| 最終レビュー | ✅ approved | 最終差分をレビュー済み |

`format` が `n/a` なのは、このリポジトリでは Biome の `npm run check` が lint と format を兼ねるためです。lint のスキップはなく、`lint_available=true` です。

## 受け入れ条件

- [x] production 環境ではプレビュー右下に `Debug` ボタンを表示しない実装とテスト定義がある
- [x] 開発時のみレイアウト検証 UI を利用できる導線を維持する
- [x] GitHub Pages 相当の production build で Debug UI が露出しないテスト定義がある
- [x] 既存のプレビュー表示・印刷・PDF 保存フローに関わる主要コントロールが有効であることを回帰テストする
- [x] リポジトリ標準の build / lint / typecheck / unit test が通る

受け入れ条件に対するテスト定義は 5/5 をカバーしています。production Chromium の実行確認のみ、上記 sandbox 制約のため CI での確認が必要です。

## スコープ外

- Debug overlay 自体の全面削除
- レイアウト検証ロジックの再設計
- 印刷レイアウト仕様の変更
- 漢字データ、依存関係、localStorage スキーマの変更

## 影響範囲 / リスク

- production UI では Debug overlay をマウントしなくなるため、利用者向け画面から開発用 UI とショートカットが除外されます
- development UI では既存の Debug overlay 導線を維持します
- Playwright に production 専用 project と fresh preview 起動設定を追加します
- 印刷レイアウト計算、PDF 生成、漢字データには変更ありません
- ローカルでは Chromium 起動が sandbox に阻止されたため、production E2E runtime の最終確認は CI に依存します
- セキュリティレビューで findings はありません

## レビュー観点

- `import.meta.env.DEV` による分岐が production build で確実に tree-shake / 非表示化されるか
- development 環境で Debug overlay の既存アクセス手段が維持されているか
- `production-chromium` が GitHub Pages のベースパスを正しく再現しているか
- production E2E が Debug UI とショートカットの両方を検出し、主要コントロールの回帰も確認しているか
- fresh preview 起動設定が既存の Playwright project に意図しない影響を与えないか

## スクリーンショット / 出力例

未添付です。managed macOS sandbox によりブラウザ起動がブロックされたため、ローカルでスクリーンショットを取得できませんでした。UI の変更は CI 上の production E2E 回帰テストで確認します。

---

Generated by Codex auto-resolve / Reviewed by knishioka-pm